### PR TITLE
Guest cart cleanup

### DIFF
--- a/api/carts.js
+++ b/api/carts.js
@@ -1,5 +1,6 @@
 const express = require("express");
-const { assignItemToCart, attachItemsToCarts } = require("../db");
+const { del } = require("express/lib/application");
+const { assignItemToCart, attachItemsToCarts, deleteAbandonedGuestCarts } = require("../db");
 const {
   getActiveCart,
   getPurchasedCartsByUser,
@@ -82,3 +83,9 @@ router.get("/allcarts", requireAdmin, async (req, res, next) => {
   }
 });
 module.exports = router;
+
+router.post("/guestcartcleanup", requireAdmin, async (req, res, next) => {
+  try {
+    await deleteAbandonedGuestCarts()
+  }catch(error){throw error}
+})

--- a/api/carts.js
+++ b/api/carts.js
@@ -53,7 +53,7 @@ router.post("/newguestcart", async (req, res, next) => {
     if (cartItems.length)
       cartItems.map((item) => {
         //put each item in the cart
-        await assignItemToCart(cart.id, item.id, item.quantity, item.price);
+        assignItemToCart(cart.id, item.id, item.quantity, item.price);
       });
     fullCart = await attachItemsToCarts([cart]);
     res.send(fullCart);

--- a/api/carts.js
+++ b/api/carts.js
@@ -53,7 +53,7 @@ router.post("/newguestcart", async (req, res, next) => {
     if (cartItems.length)
       cartItems.map((item) => {
         //put each item in the cart
-        assignItemToCart(cart.id, item.id, item.quantity, item.price);
+        await assignItemToCart(cart.id, item.id, item.quantity, item.price);
       });
     fullCart = await attachItemsToCarts([cart]);
     res.send(fullCart);

--- a/db/carts.js
+++ b/db/carts.js
@@ -170,6 +170,25 @@ async function getAllPurchasedCarts() {
   }
 }
 
+async function deleteAbandonedGuestCarts() {
+  try {
+    await client.query(
+      `DELETE FROM cart_items WHERE id IN 
+        (
+          SELECT cart_items.id as ccid FROM
+          cart_itmes JOIN carts ON
+          carts.id = cart_items.cart_id
+          WHERE purchased = false and
+          user_id = 9999
+        );
+       DELETE FROM carts WHERE
+       purchased = false AND
+       user_id = 9999;
+      `
+    )
+  } catch(error) {throw error}
+}
+
 module.exports = {
   createCart,
   deleteActiveCart,
@@ -178,4 +197,5 @@ module.exports = {
   getActiveCart,
   getAllPurchasedCarts,
   getActiveCartId,
+  deleteAbandonedGuestCarts
 };


### PR DESCRIPTION
Adds new POST route to /carts/guestcartcleanup/ that deletes guest carts and associated cart items for carts that have not been purchased.  This is an admin-only route that should have front end controls in the admin page.  

Unpurchased guest carts will be lost, but the only case in which user functionality will be compromised is if there is a non-logged-in user on the checkout page when the code is executed, and when their purchase fails, they will be able to attempt checkout without losing their cart, as the data remains in local storage on the client side until the last step of checkout, at the same moment when purchased is set to true.